### PR TITLE
Add plain HTML/CSS version with wider browser support

### DIFF
--- a/test-compat.html
+++ b/test-compat.html
@@ -1,34 +1,12 @@
-# I Stand
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Page</title>
+  </head>
+  <body>
 
-A web component to embed in your personal site to show you stand with the protests against racism and police brutality.
-
-![A banner showing solidarity with protestors against police brutality](./screenshot.png)
-
-To add this banner to your site, include the following code:
-
-```html
-<!-- Somewhere in your page -->
-<script src="https://unpkg.com/i-stand/black-lives.js" type="module"></script>
-
-<!-- After the opening <body> tag -->
-<black-lives></black-lives>
-```
-
-The snippet above will always use the latest version of the banner. This means if any changes are published they'll automatically be pulled in (such as new names or updated links).
-
-If you want to use a specific version, you can update the [unpkg](https://unpkg.com/) url to point to a specific version. For example, to always use the `v1.1.0` release, include the following script instead:
-
-```html
-<script src="https://unpkg.com/i-stand@1.1.0/black-lives.js" type="module"></script>
-```
-
-## Older browsers
-
-The above should work in all modern browsers. If you'd like to support legacy browsers however, consider copying the below plain HTML version instead.
-
-This uses CSS instead of a Shadow DOM, and thus is not isolated from your web page's own styles. This will work fine on most sites in practice, but you may need to make minor adjustments to the CSS if there are significant conflicts.
-
-```html
 <!-- <blacklives> -->
 <style>
 .blacklives-i-stand {
@@ -113,4 +91,6 @@ This uses CSS instead of a Shadow DOM, and thus is not isolated from your web pa
   <p><small><a href="https://github.com/trentmwillis/i-stand" target="_blank" rel="noreferrer">Embed this on your site.</a></small></p>
 </div>
 <!-- </blacklives> -->
-```
+
+  </body>
+</html>


### PR DESCRIPTION
Fixes https://github.com/trentmwillis/i-stand/issues/1.

I considered using `all: revert` but realized that it doesn't work yet in browsers besides Firefox.

I also considered using `all: initial` or `all: unset` but it quickly became a mess. I'm willing to give that another go though if you prefer. That would mean that in modern browsers it has more or less the same guruantees as Shadow DOM, but woul degrade in  legacy browsers with the same, slightly different, or very differnet rendering depending on what the site-local conflicts would be. I preferred the approach I submitted here as it makes it the same in all browsers and thus doesn't require the developer to test it out on the legacy browsers they want to support. Any conflicts would either be minor and acceptable, or dealt with by them upfront.

Thanks for sharing this repo ❤️  